### PR TITLE
Remove redundant derivied Typeable instance

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,14 +8,15 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250801
+# version: 0.19.20260104
 #
-# REGENDATA ("0.19.20250801",["github","cabal.project"])
+# REGENDATA ("0.19.20260104",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
   - push
   - pull_request
+  - merge_group
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
@@ -28,6 +29,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.1
+            compilerKind: ghc
+            compilerVersion: 9.14.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.12.2
             compilerKind: ghc
             compilerVersion: 9.12.2
@@ -178,7 +184,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: source
       - name: initial cabal.project for sdist

--- a/cabal.project
+++ b/cabal.project
@@ -2,23 +2,3 @@ packages: .
 
 tests: True
 test-show-details: direct
-
-if impl (ghc >= 9.14)
-  allow-newer:
-    , async:base
-    , Cabal:Cabal-syntax
-    , Cabal:containers
-    , Cabal:time
-    , Cabal-syntax:containers
-    , entropy:binary
-    , entropy:Cabal
-    , entropy:Cabal-syntax
-    , entropy:containers
-    , entropy:filepath
-    , entropy:text
-    , entropy:time
-    , entropy:unix
-    , hashable:base
-    , hashable:ghc-bignum
-    , stm:base
-    , unix:time

--- a/nonce.cabal
+++ b/nonce.cabal
@@ -21,8 +21,9 @@ description:
   nonces generated via this package are usable on your design.
 
 tested-with:
-    GHC==9.12.2, GHC==9.10.2, GHC==9.8.4, GHC==9.6.7, GHC==9.4.8, GHC==9.2.8, GHC==9.0.2
-  , GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2
+    GHC==9.14.1, GHC==9.12.2, GHC==9.10.2, GHC==9.8.4, GHC==9.6.7
+      , GHC==9.4.8, GHC==9.2.8, GHC==9.0.2, GHC==8.10.7, GHC==8.8.4
+      , GHC==8.6.5, GHC==8.4.4, GHC==8.2.2
 
 source-repository head
   type:     git

--- a/src/Crypto/Nonce.hs
+++ b/src/Crypto/Nonce.hs
@@ -35,7 +35,6 @@ module Crypto.Nonce
 import Control.Monad (liftM)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import qualified System.Entropy as Entropy
-import Data.Typeable (Typeable)
 import Control.Monad.IO.Unlift (MonadUnliftIO)
 import UnliftIO.Exception (bracket)
 
@@ -47,7 +46,6 @@ import qualified Data.Text.Encoding as TE
 
 -- | An encapsulated nonce generator.
 newtype Generator = G Entropy.CryptHandle
-  deriving (Typeable)
 
 instance Show Generator where
   show _ = "<NonceGenerator>"


### PR DESCRIPTION
GHC has automatically derived Typeable instance since about ghc-8.6.